### PR TITLE
overlay: power_profile: Fix battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -71,7 +71,7 @@
     <array name="memory.bandwidths">
         <value>22.7</value>
     </array>
-    <item name="battery.capacity">3460</item>
+    <item name="battery.capacity">4000</item>
     <item name="wifi.controller.idle">0.19</item>
     <item name="wifi.controller.rx">148.18</item>
     <item name="wifi.controller.tx">395.03</item>


### PR DESCRIPTION
Xperia 5II battery capacity is 4000mAh and not 3460mAh.

Change this value so system reports correct value.